### PR TITLE
Adjust djlint settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -83,7 +83,8 @@ repos:
   - repo: https://github.com/djlint/djLint/
     rev: v1.34.1
     hooks:
-      - id: djlint-reformat-django
+      - id: djlint
+        args: [--reformat]
         stages: [pre-commit, pre-merge-commit]
   - repo: https://github.com/pycqa/isort
     rev: 5.13.2

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
     }
   },
   "[html][django-html]": {
+    "editor.detectIndentation": false,
     "editor.defaultFormatter": "monosans.djlint"
   }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ pytest-django = "*"
 [tool.autopep8]
 
 [tool.djlint]
+profile = "django"
+max_blank_lines = 1
 
 [tool.isort]
 


### PR DESCRIPTION
- Allow for one blank line in order to add spacing around Django tags.

- Let VSCode ignore indentation of html files in order for them to format correctly upon save with 4 spaces of indentation. If option 'editor.detectIndentation' is left with its default value 'true', then an html file with 2 spaces indent is not automatically reformatted to 4 spaces indentation.