### PR TITLE
Integrate pylint-django

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -525,6 +525,38 @@ spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
 
 [[package]]
+name = "pylint-django"
+version = "2.5.5"
+description = "A Pylint plugin to help Pylint understand the Django web framework"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pylint_django-2.5.5-py3-none-any.whl", hash = "sha256:5abd5c2228e0e5e2a4cb6d0b4fc1d1cef1e773d0be911412f4dd4fc1a1a440b7"},
+    {file = "pylint_django-2.5.5.tar.gz", hash = "sha256:2f339e4bf55776958283395c5139c37700c91bd5ef1d8251ef6ac88b5abbba9b"},
+]
+
+[package.dependencies]
+pylint = ">=2.0,<4"
+pylint-plugin-utils = ">=0.8"
+
+[package.extras]
+with-django = ["Django (>=2.2)"]
+
+[[package]]
+name = "pylint-plugin-utils"
+version = "0.8.2"
+description = "Utilities and helpers for writing Pylint plugins"
+optional = false
+python-versions = ">=3.7,<4.0"
+files = [
+    {file = "pylint_plugin_utils-0.8.2-py3-none-any.whl", hash = "sha256:ae11664737aa2effbf26f973a9e0b6779ab7106ec0adc5fe104b0907ca04e507"},
+    {file = "pylint_plugin_utils-0.8.2.tar.gz", hash = "sha256:d3cebf68a38ba3fba23a873809155562571386d4c1b03e5b4c4cc26c3eee93e4"},
+]
+
+[package.dependencies]
+pylint = ">=1.7"
+
+[[package]]
 name = "pytest"
 version = "8.2.2"
 description = "pytest: simple powerful testing with Python"
@@ -850,4 +882,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "10de0ad7186847909305e95d9decfa6c9437a2eb8d8376bd8e713a303699761b"
+content-hash = "0348c4bbf11caefc76be41b81001c1255f37dcc9017410ec1c187ccd234f4ac3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ isort = "*"
 mypy = "*"
 pre-commit = "*"
 pylint = "*"
+pylint-django = "*"
 pytest-django = "*"
 
 [tool.autopep8]
@@ -40,6 +41,8 @@ plugins = ["mypy_django_plugin.main"]
 django_settings_module = "devsearch.settings"
 
 [tool.pylint]
+django-settings-module = "devsearch.settings"
+load-plugins = "pylint_django, pylint_django.checkers.migrations"
 
 [tool.pytest.ini_options]
 DJANGO_SETTINGS_MODULE = "devsearch.settings"


### PR DESCRIPTION
pylint-django is a plugin for pylint that helps pylint to function correctly in a Django project environment.

More information can be found on
https://pypi.org/project/pylint-django/ .